### PR TITLE
Implement stack growth heuristic

### DIFF
--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -1,7 +1,8 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
-struct lock filesys_lock;
+/* Global lock used to protect file system operations. */
+extern struct lock filesys_lock;
 
 void syscall_init (void);
 

--- a/pintos-kaist/include/vm/vm.h
+++ b/pintos-kaist/include/vm/vm.h
@@ -3,6 +3,10 @@
 #include <stdbool.h>
 #include <hash.h>
 #include "threads/palloc.h"
+#include "threads/vaddr.h"
+
+/* Maximum size of user stack is 1 MB. */
+#define STACK_HEURISTIC 8
 
 /* ─────────────────────────────────────────────
    가상 페이지의 종류(enum vm_type)

--- a/pintos-kaist/include/vm/vm.h
+++ b/pintos-kaist/include/vm/vm.h
@@ -5,8 +5,12 @@
 #include "threads/palloc.h"
 #include "threads/vaddr.h"
 
-/* Maximum size of user stack is 1 MB. */
-#define STACK_HEURISTIC 8
+/*
+ * Number of bytes below the current stack pointer which we still
+ * regard as a valid stack access.  If a faulting address lies within
+ * this range, the stack is allowed to grow.
+ */
+#define STACK_HEURISTIC 32
 
 /* ─────────────────────────────────────────────
    가상 페이지의 종류(enum vm_type)

--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -810,7 +810,8 @@ setup_stack(struct intr_frame *if_)
 	{
 		success = install_page(((uint8_t *)USER_STACK) - PGSIZE, kpage, true);
 		if (success)
-			if_->rsp = USER_STACK;
+                        if_->rsp = USER_STACK;
+                        thread_current()->rsp = USER_STACK;
 		else
 			palloc_free_page(kpage);
 	}

--- a/pintos-kaist/userprog/syscall.c
+++ b/pintos-kaist/userprog/syscall.c
@@ -19,6 +19,9 @@ bool create(const char *file, unsigned initial_size);
 bool remove(const char *file) ;
 void check_address(const uint64_t *addr);
 
+/* Definition of the global file system lock declared in syscall.h. */
+struct lock filesys_lock;
+
 /* System call.
  *
  * Previously system call services was handled by the interrupt handler

--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -343,8 +343,12 @@ bool vm_try_handle_fault(struct intr_frame *f, void *addr,
        {
                /* Grow stack if the faulting access is close enough to the
                   current stack pointer and within the user stack region. */
-               if (addr >= rsp_stack - STACK_HEURISTIC && addr >= STACK_MAX && addr < USER_STACK)
+               if (addr >= rsp_stack - STACK_HEURISTIC &&
+                   addr >= STACK_MAX && addr < USER_STACK)
+               {
                        vm_stack_growth(addr);
+                       return true;
+               }
        }
 
         struct page *page = spt_find_page(spt, addr);

--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -260,12 +260,16 @@ vm_stack_growth(void *addr)
 {
         /* Allocate a new anonymous stack page at the given address. */
         void *addr_aligned = pg_round_down(addr);
-        /* Create an uninitialised page marked as stack. */
+
         if (vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_STACK,
                                            addr_aligned, true, NULL, NULL))
         {
                 /* Immediately claim the page so that it becomes usable. */
                 vm_claim_page(addr_aligned);
+
+                /* Track the lowest stack address allocated so far. */
+                if (addr_aligned < thread_current()->rsp)
+                        thread_current()->rsp = addr_aligned;
         }
 }
 


### PR DESCRIPTION
## Summary
- implement vm_stack_growth to allocate and claim stack pages
- add stack growth heuristic in vm_try_handle_fault
- remove debug prints
- introduce `STACK_HEURISTIC` constant in vm.h

## Testing
- `make build/tests/vm/pt-grow-stack.result NOCHECK=1` *(fails: kernel build error)*

------
https://chatgpt.com/codex/tasks/task_e_68415bac193c833294421d2f002738c2