### PR TITLE
Fix protection check in read syscall

### DIFF
--- a/pintos-kaist/include/userprog/syscall.h
+++ b/pintos-kaist/include/userprog/syscall.h
@@ -1,7 +1,7 @@
 #ifndef USERPROG_SYSCALL_H
 #define USERPROG_SYSCALL_H
 
-struct lock filesys_lock;
+extern struct lock filesys_lock;
 
 void syscall_init (void);
 


### PR DESCRIPTION
## Summary
- prevent writing into read-only pages by checking writable page flag before file read
- declare `filesys_lock` as external in header and define it in syscall.c

## Testing
- `cd pintos-kaist/vm && make`

------
https://chatgpt.com/codex/tasks/task_e_6841af2961408332afb4fc7016ee526c