### PR TITLE
Fix mmap munmap handling

### DIFF
--- a/pintos-kaist/userprog/process.c
+++ b/pintos-kaist/userprog/process.c
@@ -20,10 +20,6 @@
 #include "threads/vaddr.h"
 #include "intrinsic.h"
 #include "vm/vm.h"
-#define VM
-
-#ifdef VM
-#endif
 
 static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);

--- a/pintos-kaist/vm/file.c
+++ b/pintos-kaist/vm/file.c
@@ -77,21 +77,15 @@ file_backed_destroy(struct page *page)
 	//   - write-back 구현
 	
 	struct file_page *file_page = &page->file; 
-	struct pml4 *pml4 = thread_current()->pml4;
-	struct supplemental_page_table *spt = &thread_current()->spt;
-	
-	if (pml4_is_dirty(pml4, page->va))
-	{
-		// write back
-		file_write_at(file_page->file, page->va, file_page->size, file_page->file_ofs); // Writes SIZE bytes만큼 쓴다.
-	}
-	
-	/* 
-	* DEBUG: spt_remove_page를 여기서 호출하면 중복이다. 위의 주석을 참조.
-	*/
-	// spt_remove_page(spt, page); // spt 제거 -> spt에서 지우면 pml4에서 계속 업데이트가 된다?
-	
+       struct pml4 *pml4 = thread_current()->pml4;
+       struct supplemental_page_table *spt = &thread_current()->spt;
 
+       if (pml4_is_dirty(pml4, page->va))
+       {
+               // write back
+               file_write_at(file_page->file, page->va, file_page->size, file_page->file_ofs); // Writes SIZE bytes만큼 쓴다.
+       }
+       spt_remove_page(spt, page);
 }
 
 /* Do the mmap */
@@ -168,33 +162,24 @@ void do_munmap(void *addr)
 	// 프로세스가 종료되면 매핑 자동해제. munmap할 필요는 없음.
 	// 매핑 해제 시 수정된 페이지는 파일에 반영
 	// 수정되지 않은 페이지는 반영할 필요 없음.
-	dprintfg("[do_munmap] routine start. va: %p\n", addr);
+       dprintfg("[do_munmap] routine start. va: %p\n", addr);
 
-	struct supplemental_page_table *spt = &thread_current()-> spt; // 현재 스레드의 spt 정보 참조
-	struct page *page = spt_find_page(spt, addr); // spt정보를 가져온다.
-		void *addr_buf = page->va;
-	struct file *file = page->file.file;
-	if (page->file.cnt != 0 || page_get_type(page) != VM_FILE)
-	{
-		// undefined action
-		dprintfg("[do_munmap] undefined action! expected type: %d, actual: %d\n", (VM_FILE | VM_FILE_FIRST) , page->uninit.type);
-		exit(-1);
-	}
+       struct thread *curr = thread_current();
+       struct supplemental_page_table *spt = &curr->spt;
+       struct page *page;
+       struct file *file = NULL;
 
-	// 주소를 역으로 올라가며 페이지를 삭제.
-	// 또다른 시작 페이지를 만나면 정지.
-	while(page != NULL && page->uninit.type == VM_FILE)
-	{
-		dprintfg("[do_munmap] deleting page. va: %p\n", page->va);
-		addr_buf = page->va; // 페이지 구조체를 제거하기 전 주소 저장
-		file_backed_destroy(page); // 페이지 제거
-		page = spt_find_page(spt, addr_buf + PGSIZE); // 기존 주소보다 한 페이지 위에 주소의 페이지를 획득.
-		if (page->file.cnt == 0 || page_get_type(page) != VM_FILE) // 만약 또다른 파일 페이지의 시작이라면 제거 정지.
-		{
-			break;
-		}
-	}
-	file_close(file); // 파일을 닫습니다. 해당 파일 구조체는 mmap 시 reopen 되어 독립적인 카운트를 유지합니다.
+       while ((page = spt_find_page(spt, addr)) != NULL && page_get_type(page) == VM_FILE)
+       {
+               if (file == NULL)
+                       file = page->file.file;
+
+               addr += PGSIZE;
+               file_backed_destroy(page);
+       }
+
+       if (file != NULL)
+               file_close(file);
 
 	dprintfg("[do_munmap] munmap complete!\n");
 }

--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -186,10 +186,8 @@ bool spt_insert_page(struct supplemental_page_table *spt,
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
 {
-	hash_delete(&spt, &page->hash_elem);
-	vm_dealloc_page(page);
-
-	return true;
+        hash_delete(&spt->hash, &page->hash_elem);
+        vm_dealloc_page(page);
 }
 
 /* 교체될 프레임(struct frame)을 선택하여 가져옵니다. */


### PR DESCRIPTION
## Summary
- clean up VM define in process.c
- write back file pages and remove from SPT on unmap
- correct spt_remove_page implementation

## Testing
- `make` *(fails: `userprog/syscall.c` build errors)*
- `pintos -v -k -T 60 -m 20 --fs-disk=10 -p tests/vm/mmap-write:mmap-write --swap-disk=4 -- -q -f run mmap-write` *(fails: `os.dsk cannot be temporal`)*

------
https://chatgpt.com/codex/tasks/task_e_68439c449e4083329c9f4c88b10f7601