### PR TITLE
Improve mmap/munmap implementation

### DIFF
--- a/pintos-kaist/vm/vm.c
+++ b/pintos-kaist/vm/vm.c
@@ -186,10 +186,12 @@ bool spt_insert_page(struct supplemental_page_table *spt,
 
 void spt_remove_page(struct supplemental_page_table *spt, struct page *page)
 {
-	hash_delete(&spt, &page->hash_elem);
-	vm_dealloc_page(page);
+        if (page == NULL || spt == NULL)
+                return;
 
-	return true;
+        hash_delete(&spt->hash, &page->hash_elem);
+        pml4_clear_page(thread_current()->pml4, page->va);
+        vm_dealloc_page(page);
 }
 
 /* 교체될 프레임(struct frame)을 선택하여 가져옵니다. */


### PR DESCRIPTION
## Summary
- refine `file_backed_destroy` to flush changes from the frame
- rewrite `do_mmap` to create mapping structures and handle failures
- rewrite `do_munmap` to properly remove mappings
- fix `spt_remove_page` logic

## Testing
- `make -C vm` *(fails: multiple definition of filesys_lock)*

------
https://chatgpt.com/codex/tasks/task_e_6843ab008d9c83328dafa4857b94927c